### PR TITLE
take file contents directly from git

### DIFF
--- a/reno/lister.py
+++ b/reno/lister.py
@@ -28,8 +28,8 @@ def list_cmd(args):
     for version in versions:
         notefiles = notes[version]
         print(version)
-        for n in notefiles:
+        for n, sha in notefiles:
             if n.startswith(reporoot):
                 n = n[len(reporoot):]
-            print('\t%s' % n)
+            print('\t%s (%s)' % (n, sha))
     return


### PR DESCRIPTION
Rather than reading files that may not exist because they are only on a
branch, use git show to pull the contents of the file out of the git
history as we need them. This must be slower than reading the file
directly, but does allow us to process branches separately without
actually checking them out. To do it, we have to track not just the most
recent name of a file with a given prefix, but the sha where that file
appears.

Change-Id: I2700be3066fff9cacba77d33a9e29949b6c1090f